### PR TITLE
Fix header stickiness on mobile

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -149,6 +149,32 @@ export default class StickyTableHeadersPlugin extends Plugin {
             }
         });
 
+		this.registerEvent(
+			this.app.workspace.on("css-change", () => {
+				// if --file-margins-top doesn't exist on body,
+				// check if --file-margins exists on body, and then
+				// extract just the "top" value.
+				// if --file-margins doesn't exist, don't set --file-margins-top
+
+				const varBase = document.body;
+
+				const fileMargins = getComputedStyle(varBase)
+					.getPropertyValue("--file-margins")
+					.trim();
+				const fileMarginsTop = getComputedStyle(varBase)
+					.getPropertyValue("--file-margins-top")
+					.trim();
+
+				if ((!fileMarginsTop) && fileMargins) {
+					// We have file-margins, but not file-margins-top
+					// Let's figure out what it should be, and create it.
+					const fileMarginsArray = fileMargins.split(" ");
+					const fileMarginsTop = fileMarginsArray[0];
+					varBase.style.setProperty("--file-margins-top", fileMarginsTop);
+				}
+			})
+		);
+
         // Notify Style Settings about new plugin
         this.app.workspace.trigger("parse-style-settings");
     }

--- a/styles.css
+++ b/styles.css
@@ -30,7 +30,7 @@ settings:
 .markdown-source-view.mod-cm6 .cm-table-widget th,
 .markdown-reading-view .el-table thead th {
     position: sticky;
-    top: calc(-1 * var(--file-margins) - 1px); /* Handle border gap */
+    top: calc(-1 * var(--file-margins-top, 1px) - 1px); /* Handle border gap */
     z-index: 1000;
 }
 


### PR DESCRIPTION
The default --file-margins value on mobile is '8px 24px', while it's single-valued, '32px', on desktop.

I added a little JavaScript that adds a --file-margins-top using --file-margins.

It seems to work fine on desktop and mobile.

For https://github.com/adamwolf/sticky-table-headers/issues/4