### PR TITLE
Clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,4 @@ Obsidian won't automatically pick up changes in your files.
 
 sticky-table-headers is licensed under the GNU GPL v3.0 license.  Alternative licensing arrangements may be available upon request.
 
-sticky-table-headers was started from a template at https://github.com/obsidianmd/obsidian-sample-plugin/commit/6d09ce3e39c4e48d756d83e7b51583676939a5a7 which contained the following:
-
-> Copyright (C) 2020-2025 by Dynalist Inc.
-> 
-> Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+sticky-table-headers was started from a template at https://github.com/obsidianmd/obsidian-sample-plugin/commit/6d09ce3e39c4e48d756d83e7b51583676939a5a7.

--- a/main.ts
+++ b/main.ts
@@ -40,7 +40,7 @@ export default class StickyTableHeadersPlugin extends Plugin {
                                 return;
                             }
 
-                            const scrollHandler = (event: Event) => {
+                            const scrollHandler = () => {
                                 try {
                                     const headerRect = thead.getBoundingClientRect();
                                     const scrollerRect = scroller.getBoundingClientRect();


### PR DESCRIPTION
This removes an unused parameter from JavaScript and removes some confusing license text from the README.