### PR TITLE
Fix background header colors and set defaults

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4,20 +4,38 @@ name: Sticky Table Headers
 id: sticky-table-headers
 settings:
     -
-        id: sticky-table-headers-custom-floating-headers
-        title: Customize floating table header background
-        description: Enable custom styling for table headers when they're floating
-        type: class-toggle
-        default: true
-    -
-        id: sticky-table-headers-floating-table-header-background
-        title: Floating header background
-        description: Background color for floating table headers
+        id: sticky-table-headers-floating-table-header-background-light
+        title: Floating header background color (light theme)
         type: variable-color
         opacity: true
         format: hex
-        default: '#FAFAFA'
+        default: '#F6F6F6'
+    -
+        id: sticky-table-headers-floating-table-header-background-dark
+        title: Floating header background color (dark theme)
+        type: variable-color
+        opacity: true
+        format: hex
+        default: '#262626'
 */
+
+body {
+    --sticky-table-headers-floating-table-header-background: var(--background-secondary);
+}
+
+body.theme-light {
+    --sticky-table-headers-floating-table-header-background: var(
+        --sticky-table-headers-floating-table-header-background-light,
+        var(--background-secondary)
+    );
+}
+
+body.theme-dark {
+    --sticky-table-headers-floating-table-header-background: var(
+        --sticky-table-headers-floating-table-header-background-dark,
+        var(--background-secondary)
+    );
+}
 
 .markdown-reading-view .el-table {
     overflow: visible !important;
@@ -34,6 +52,11 @@ settings:
     z-index: 1000;
 }
 
-body.sticky-table-headers-custom-floating-headers table.header-floating thead th {
-    background-color: var(--sticky-table-headers-floating-table-header-background);
+.markdown-source-view.mod-cm6 .cm-table-widget th,
+.markdown-reading-view .el-table thead th,
+table.header-floating thead th {
+    background-color: var(
+        --sticky-table-headers-floating-table-header-background,
+        var(--background-secondary)
+    );
 }

--- a/styles.css
+++ b/styles.css
@@ -46,15 +46,15 @@ body.theme-dark {
 }
 
 .markdown-source-view.mod-cm6 .cm-table-widget th,
-.markdown-reading-view .el-table thead th {
+.markdown-reading-view .el-table thead tr > th {
     position: sticky;
     top: calc(-1 * var(--file-margins-top, 1px) - 1px); /* Handle border gap */
     z-index: 1000;
 }
 
 .markdown-source-view.mod-cm6 .cm-table-widget th,
-.markdown-reading-view .el-table thead th,
-table.header-floating thead th {
+.markdown-reading-view .el-table thead tr > th,
+table.header-floating thead tr > th {
     background-color: var(
         --sticky-table-headers-floating-table-header-background,
         var(--background-secondary)


### PR DESCRIPTION
Fixes a bug where the header background would sometimes be transparent even when a color was set.

Also sets the default header background color to the color of the sidebar background,  --background-secondary. If that color changes, the header background will update. The user can override the color with Style Settings, and have separate color values for light and dark mode.